### PR TITLE
feat!: update treesitter queries, highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With lazy.nvim:
   {
     'gsuuon/note.nvim',
     opts = {
-      -- Spaces are note roots. These directories should contain a `./notes` directory (will be made if not).
+      -- opts.spaces are note workspace parent directories. These directories contain a `notes` directory (will be created if missing) which acts as the note root. So for the space '~' the note root will be `~/notes`.
       -- Defaults to { '~' }.
       spaces = {
         '~',
@@ -47,13 +47,15 @@ https://github.com/gsuuon/note.nvim/assets/6422188/27fbbc66-6a6a-49ef-94ca-25e4e
 The treesitter highlight groups are linked in [ftplugin/note.lua](ftplugin/note.lua) and the group queries are in [queries/note/highlights.scm](queries/note/highlights.scm). You can customize these by overriding the groups with your own links or highlights.
 
 ## Usage
-Open the daily note with `:Note`. This can be scoped to a workspace root with the `spaces` config option:
+Open the daily note with `:Note`. This can be scoped to a workspace root with the `spaces` config option.
 ```lua
 require('note').setup({
   spaces = { '~', '~/myproject' }
 })
 ```
-You can create a custom template for daily notes at `[note_root]/.note/daily_template`. note comes with [treesitter based highlighting](#tree-sitter) but falls back to a syntax file if the grammar is not installed.
+The active space will be the first path which contains the current working directory. Spaces are matched bottom up, so the least specific path should be first. The "note root" is `<space path>/notes/` - all note actions (daily notes, templating, rooted links) are done relative to this directory.
+
+You can create a custom template for daily notes at `<note root>/.note/daily_template`. note comes with [treesitter based highlighting](#tree-sitter) but falls back to a syntax file if the grammar is not installed.
 
 [Keymaps](#keymaps) are added for note.nvim commands with a default prefix of `<leader>n`.
 
@@ -67,7 +69,11 @@ Items can be properties or tasks. The first character is a marker that indicates
   . sub task
 ```
 
-Items are indent scoped - a newline and 2 spaces start a child item scope. They can contain any text content. Anything below an item which doesn't start a new scope becomes part of the text content of that item.
+Items are indentation scoped - a newline and 2 spaces deeper indent followed by a marker starts a child item scope. An item can contain any text on the same line, which becomes the item content. Items can also contain body content (any freeform text) as long as it doesn't start with a marker character. Item bodies can contain code blocks with markdown style codefences.
+> [!IMPORTANT]
+> Each indent level is 2 spaces and each scope can only be one level deeper than the previous one.
+
+An item with a code block body:
 ````
 - a pending task
 ```js
@@ -90,21 +96,25 @@ const scratchFn = () => {}
 #### Sections
 `#` — section -- Not indented - the number of #'s mean depth like markdown.  
 
-### Modifiers
-Some special symbols will also highlight to help with readability:
+### Decorators
+Decorators are special symbols to help with readability. They have [default highlight group](#highlights) links which can be overriden, or you can set `opts.disable_decorators = true` to disable decorator highlighting.
 
-`->` — flow -- indicates one thing flowing to another  
-`<-` — select -- indicates selecting one of a list  
+` -> ` — flow -- indicates one thing flowing to another  
+` <-` — select -- indicates selecting one of a list  
 `(?)` — question -- draw attention to something confusing  
 `(!)` — warn -- draw attention to something important  
 
-### Links
-Links to items are created by simply writing text like `[(<file>)<marker>|<body>]`. Follow a link by putting the cursor over it and calling `:NoteGoLink`. This will search for a target item first by looking downwards from the link and then upwards. The file part can point to a specific commit.
 
-- `<body>` behaves like a case-insensitive `string.match` against items.
-- `(<file>)` if present links to that file relative to the current file - the path is joined with the current file's directory. If the file part starts with `/` then the path is resolved relative to the note root.
-- `(<file>@<commit>)` links to the file at a specific commit. The git root must be the same as the note workspace root.  
-- `<marker>` is a specific marker (e.g. `-`, `*`) or one of these special characters:
+### Links
+> [!WARNING]
+> **The link format has changed from `[<link>]` to `{{<link>}}`**. Use `:NoteConvertLinksSquareToCurly` in files with square bracket links to update them.
+
+You can create a link by writing `{{(<file>)<marker>|<content>}}`, where `<thing>` is a thing to be replaced (see below for examples). Follow a link by moving your cursor over it and running `:NoteGoLink`. This will search for a target item first by looking downwards from the link and then upwards. The file part can point to a specific commit.
+
+- `<content>` behaves like a case-insensitive `string.match` against item content.  
+- `(<file>)` links to `<file>` relative to the current file. The target path is joined with the current file's directory. If `<file>` starts with `/` then it will resolve relative to the note workspace root (e.g. `~/notes`). A link can just point to a file without specifying a marker or body.  
+- `(<file>@<commit>)` links to the file at a specific commit. The git root is assumed to be the same as the note workspace root.  
+- `<marker>` is a specific item marker (e.g. `-`, `*`) or one of these special characters:
 
 `s` — section -- matches any number of #'s  
 `p` — property -- matches any property marker  
@@ -112,9 +122,10 @@ Links to items are created by simply writing text like `[(<file>)<marker>|<body>
 
 For example:
 
-`[t|clean]` links to a task containing 'clean'  
-`[(chores)s|daily]` links to a file in the same directory as the current file named 'chores' and finds the first section with 'daily'  
-`[(/budget)t|groceries]` links to the 'budget' file in the note root and finds the first 'groceries' task  
+`{{t|clean}}` links to a task containing 'clean'  
+`{{(chores)s|daily}}` links to a file in the same directory as the current file named 'chores' and finds the first section with 'daily'  
+`{{(/budget)t|groceries}}` links to the 'budget' file in the note root and finds the first 'groceries' task  
+`{{(/tasks)}}` links to the 'tasks' file in the note root
 
 ## Examples
 ![note](https://github.com/gsuuon/note.nvim/assets/6422188/813e74e7-d9dc-4b5f-b433-4ef294491797)
@@ -132,13 +143,13 @@ For example:
   > Pick up toys
 ```
 
-`[t|monday]` links to the `- Monday` task and `[(../health)s|goal]` links to the the 'health' file up one directory at a section matching `goal`.
+`{{t|monday}}` links to the `- Monday` task and `{{(../health)s|goal}}` links to the the 'health' file up one directory at a section matching `goal`.
 ```
-[t|monday]
+{{t|monday}}
 # Gym
 - Monday
   - Squats
-[(../health)s|goal]
+{{(../health)s|goal}}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ With lazy.nvim:
   {
     'gsuuon/note.nvim',
     opts = {
-      -- opts.spaces are note workspace parent directories. These directories contain a `notes` directory (will be created if missing) which acts as the note root. So for the space '~' the note root will be `~/notes`.
+      -- opts.spaces are note workspace parent directories.
+      -- These directories contain a `notes` directory which will be created if missing.
+      -- `<space path>/notes` acts as the note root, so for space '~' the note root is `~/notes`.
       -- Defaults to { '~' }.
       spaces = {
         '~',
@@ -41,7 +43,7 @@ A [tree-sitter grammar](https://github.com/gsuuon/tree-sitter-note) can be insta
 
 https://github.com/gsuuon/note.nvim/assets/6422188/27fbbc66-6a6a-49ef-94ca-25e4e5eeb3b9
 
-> [!INFO]
+> [!NOTE]
 > The tree-sitter grammar currently assumes unix newlines, if tree-sitter parser is installed then note will :set ff=unix in note filetype buffers
 
 #### Highlights
@@ -98,7 +100,7 @@ const scratchFn = () => {}
 `#` — section -- Not indented - the number of #'s mean depth like markdown.  
 
 ### Decorators
-Decorators are special symbols to help with readability. They have [default highlight group](#highlights) links which can be overriden, or you can set `opts.disable_decorators = true` to disable decorator highlighting.
+Decorators are special symbols that help with readability. They have [default highlight group](#highlights) links which can be overriden, or you can set `opts.disable_decorators = true` to disable decorator highlighting.
 
 `  ->  ` — flow -- indicates one thing flowing to another  
 ` <-` — select -- indicates selecting one of a list  
@@ -124,8 +126,8 @@ You can create a link by writing `{{(<file>)<marker>|<content>}}`, where `<thing
 Link examples:
 
 `{{t|clean}}` - a task containing 'clean'  
-`{{(chores)s|daily}}` - a file in the same directory as the current file named 'chores' and finds the first section header containing 'daily'  
-`{{(/budget)t|groceries}}` - the 'budget' file in the note root and finds the first task containing 'groceries'  
+`{{(chores)s|daily}}` - a file in the same directory as the current file named 'chores', finds the first section header containing 'daily'  
+`{{(/budget)t|groceries}}` - the 'budget' file in the note root, finds the first task containing 'groceries'  
 `{{(/tasks)}}` - the 'tasks' file in the note root
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ With lazy.nvim:
 ### Tree-sitter
 A [tree-sitter grammar](https://github.com/gsuuon/tree-sitter-note) can be installed with `:TSInstall note`. The grammar includes markdown style code-fenced injections of other languages and makes it possible to use treesitter based navigation like [tshjkl](https://github.com/gsuuon/tshjkl.nvim) with note items.
 
-
 https://github.com/gsuuon/note.nvim/assets/6422188/27fbbc66-6a6a-49ef-94ca-25e4e5eeb3b9
 
+> [!INFO]
+> The tree-sitter grammar currently assumes unix newlines, if tree-sitter parser is installed then note will :set ff=unix in note filetype buffers
 
 #### Highlights
 The treesitter highlight groups are linked in [ftplugin/note.lua](ftplugin/note.lua) and the group queries are in [queries/note/highlights.scm](queries/note/highlights.scm). You can customize these by overriding the groups with your own links or highlights.
@@ -53,7 +54,7 @@ require('note').setup({
   spaces = { '~', '~/myproject' }
 })
 ```
-The active space will be the first path which contains the current working directory. Spaces are matched bottom up, so the least specific path should be first. The "note root" is `<space path>/notes/` - all note actions (daily notes, templating, rooted links) are done relative to this directory.
+The active space will be the last path which contains the current working directory. Spaces are matched bottom up, so the least specific path should be first. The "note root" is `<space path>/notes/` - all note actions (daily notes, templating, rooted links) are done relative to this directory.
 
 You can create a custom template for daily notes at `<note root>/.note/daily_template`. note comes with [treesitter based highlighting](#tree-sitter) but falls back to a syntax file if the grammar is not installed.
 
@@ -69,7 +70,7 @@ Items can be properties or tasks. The first character is a marker that indicates
   . sub task
 ```
 
-Items are indentation scoped - a newline and 2 spaces deeper indent followed by a marker starts a child item scope. An item can contain any text on the same line, which becomes the item content. Items can also contain body content (any freeform text) as long as it doesn't start with a marker character. Item bodies can contain code blocks with markdown style codefences.
+Items are indentation scoped - a newline and 2 spaces deeper indent followed by a marker starts a child item scope. An item can contain any text on the same line, which becomes the item content. Items can also have a body (any text after the first line) as long as it doesn't start with a marker character or section header. Item bodies can contain code blocks with markdown style codefences.
 > [!IMPORTANT]
 > Each indent level is 2 spaces and each scope can only be one level deeper than the previous one.
 
@@ -99,7 +100,7 @@ const scratchFn = () => {}
 ### Decorators
 Decorators are special symbols to help with readability. They have [default highlight group](#highlights) links which can be overriden, or you can set `opts.disable_decorators = true` to disable decorator highlighting.
 
-` -> ` — flow -- indicates one thing flowing to another  
+`  ->  ` — flow -- indicates one thing flowing to another  
 ` <-` — select -- indicates selecting one of a list  
 `(?)` — question -- draw attention to something confusing  
 `(!)` — warn -- draw attention to something important  
@@ -120,12 +121,12 @@ You can create a link by writing `{{(<file>)<marker>|<content>}}`, where `<thing
 `p` — property -- matches any property marker  
 `t` — task -- matches any task marker  
 
-For example:
+Link examples:
 
-`{{t|clean}}` links to a task containing 'clean'  
-`{{(chores)s|daily}}` links to a file in the same directory as the current file named 'chores' and finds the first section with 'daily'  
-`{{(/budget)t|groceries}}` links to the 'budget' file in the note root and finds the first 'groceries' task  
-`{{(/tasks)}}` links to the 'tasks' file in the note root
+`{{t|clean}}` - a task containing 'clean'  
+`{{(chores)s|daily}}` - a file in the same directory as the current file named 'chores' and finds the first section header containing 'daily'  
+`{{(/budget)t|groceries}}` - the 'budget' file in the note root and finds the first task containing 'groceries'  
+`{{(/tasks)}}` - the 'tasks' file in the note root
 
 ## Examples
 ![note](https://github.com/gsuuon/note.nvim/assets/6422188/813e74e7-d9dc-4b5f-b433-4ef294491797)
@@ -167,7 +168,7 @@ For example:
 `NoteGoLink` — Follow the link under cursor  
 `NoteTime <marker?>` — Insert a timestamped item with marker (defaults to `*`)
 `NoteReport` — Notify with a summary of the current note  
-`NoteLinkPinCommit` — Modify the link under the cursor to pin it to the current commit (and absolute path of current file if not specified)  
+`NoteLinkPinCommit` — Modify the link under the cursor to pin it to the current commit and absolute path of current file (if not specified)  
 
 #### Refs
 `NoteRefCreate` — Create a ref for the item under the cursor  

--- a/ftplugin/note.lua
+++ b/ftplugin/note.lua
@@ -18,40 +18,43 @@ if not vim.b.did_note_plugin then
     )
   end
 
-  vim.api.nvim_set_hl(0, '@note.cancelled.content', { link = "Conceal", default = true })
-  vim.api.nvim_set_hl(0, '@note.done.content', { link = "SpecialComment", default = true })
-  vim.api.nvim_set_hl(0, '@note.current.content', { link = "ModeMsg", default = true })
-  vim.api.nvim_set_hl(0, '@note.label.content', { link = "Tag", default = true })
-  vim.api.nvim_set_hl(0, '@note.cancelled.content', { link = "Conceal", default = true })
-  vim.api.nvim_set_hl(0, '@note.info.content', { link = "Comment", default = true })
+  local function link_ts_highlight_defaults()
+    vim.api.nvim_set_hl(0, '@note.cancelled.content', { link = "Conceal", default = true })
+    vim.api.nvim_set_hl(0, '@note.done.content', { link = "SpecialComment", default = true })
+    vim.api.nvim_set_hl(0, '@note.current.content', { link = "ModeMsg", default = true })
+    vim.api.nvim_set_hl(0, '@note.label.content', { link = "Tag", default = true })
+    vim.api.nvim_set_hl(0, '@note.cancelled.content', { link = "Conceal", default = true })
+    vim.api.nvim_set_hl(0, '@note.info.content', { link = "Comment", default = true })
 
-  vim.api.nvim_set_hl(0, '@note.pending.marker', { link = "Identifier", default = true })
-  vim.api.nvim_set_hl(0, '@note.paused.marker', { link = "WarningMsg", default = true })
-  vim.api.nvim_set_hl(0, '@note.cancelled.marker', { link = "Error", default = true })
-  vim.api.nvim_set_hl(0, '@note.done.marker', { link = "Constant", default = true })
-  vim.api.nvim_set_hl(0, '@note.current.marker', { link = "QuickFixLine", default = true })
-  vim.api.nvim_set_hl(0, '@note.label.marker', { link = "Tag", default = true })
-  vim.api.nvim_set_hl(0, '@note.info.marker', { link = "Comment", default = true })
+    vim.api.nvim_set_hl(0, '@note.pending.marker', { link = "Identifier", default = true })
+    vim.api.nvim_set_hl(0, '@note.paused.marker', { link = "WarningMsg", default = true })
+    vim.api.nvim_set_hl(0, '@note.cancelled.marker', { link = "Error", default = true })
+    vim.api.nvim_set_hl(0, '@note.done.marker', { link = "Constant", default = true })
+    vim.api.nvim_set_hl(0, '@note.current.marker', { link = "QuickFixLine", default = true })
+    vim.api.nvim_set_hl(0, '@note.label.marker', { link = "Tag", default = true })
+    vim.api.nvim_set_hl(0, '@note.info.marker', { link = "Comment", default = true })
 
-  if note.config.disable_decorators == nil or note.config.disable_decorators == false then
-    vim.api.nvim_set_hl(0, '@note.decorator.select', { link = "GreenSign", default = true })
-    vim.api.nvim_set_hl(0, '@note.decorator.flow', { link = "AquaSign", default = true })
-    vim.api.nvim_set_hl(0, '@note.decorator.warn', { link = "YellowSign", default = true })
-    vim.api.nvim_set_hl(0, '@note.decorator.question', { link = "BlueSign", default = true })
+    if note.config.disable_decorators == nil or note.config.disable_decorators == false then
+      vim.api.nvim_set_hl(0, '@note.decorator.select', { link = "GreenSign", default = true })
+      vim.api.nvim_set_hl(0, '@note.decorator.flow', { link = "AquaSign", default = true })
+      vim.api.nvim_set_hl(0, '@note.decorator.warn', { link = "YellowSign", default = true })
+      vim.api.nvim_set_hl(0, '@note.decorator.question', { link = "BlueSign", default = true })
+    end
+
+    vim.api.nvim_set_hl(0, '@note.link', { link = "NormalFloat", default = true })
+
+    vim.api.nvim_set_hl(0, '@markup.heading.1.note', { link = "@markup.heading.1.markdown", default = true })
+    vim.api.nvim_set_hl(0, '@markup.heading.2.note', { link = "@markup.heading.2.markdown", default = true })
+    vim.api.nvim_set_hl(0, '@markup.heading.3.note', { link = "@markup.heading.3.markdown", default = true })
+    vim.api.nvim_set_hl(0, '@markup.heading.4.note', { link = "@markup.heading.4.markdown", default = true })
   end
-
-  vim.api.nvim_set_hl(0, '@note.link', { link = "NormalFloat", default = true })
-
-  vim.api.nvim_set_hl(0, '@markup.heading.1.note', { link = "@markup.heading.1.markdown", default = true })
-  vim.api.nvim_set_hl(0, '@markup.heading.2.note', { link = "@markup.heading.2.markdown", default = true })
-  vim.api.nvim_set_hl(0, '@markup.heading.3.note', { link = "@markup.heading.3.markdown", default = true })
-  vim.api.nvim_set_hl(0, '@markup.heading.4.note', { link = "@markup.heading.4.markdown", default = true })
-
 
   local ok, parsers = pcall(require, "nvim-treesitter.parsers")
   if ok then
     if parsers.has_parser() then
+      vim.bo.fileformat = 'unix'
       vim.opt_local.foldmethod = 'expr'
+      link_ts_highlight_defaults()
     else
       vim.opt_local.foldmethod = 'indent'
     end

--- a/ftplugin/note.lua
+++ b/ftplugin/note.lua
@@ -33,10 +33,20 @@ if not vim.b.did_note_plugin then
   vim.api.nvim_set_hl(0, '@note.label.marker', { link = "Tag", default = true })
   vim.api.nvim_set_hl(0, '@note.info.marker', { link = "Comment", default = true })
 
+  if note.config.disable_decorators == nil or note.config.disable_decorators == false then
+    vim.api.nvim_set_hl(0, '@note.decorator.select', { link = "GreenSign", default = true })
+    vim.api.nvim_set_hl(0, '@note.decorator.flow', { link = "AquaSign", default = true })
+    vim.api.nvim_set_hl(0, '@note.decorator.warn', { link = "YellowSign", default = true })
+    vim.api.nvim_set_hl(0, '@note.decorator.question', { link = "BlueSign", default = true })
+  end
+
+  vim.api.nvim_set_hl(0, '@note.link', { link = "NormalFloat", default = true })
+
   vim.api.nvim_set_hl(0, '@markup.heading.1.note', { link = "@markup.heading.1.markdown", default = true })
   vim.api.nvim_set_hl(0, '@markup.heading.2.note', { link = "@markup.heading.2.markdown", default = true })
   vim.api.nvim_set_hl(0, '@markup.heading.3.note', { link = "@markup.heading.3.markdown", default = true })
   vim.api.nvim_set_hl(0, '@markup.heading.4.note', { link = "@markup.heading.4.markdown", default = true })
+
 
   local ok, parsers = pcall(require, "nvim-treesitter.parsers")
   if ok then

--- a/lua/note/commands.lua
+++ b/lua/note/commands.lua
@@ -93,8 +93,8 @@ local function follow_link_at_cursor()
       local bufname = filepath .. '@' .. link.file.commit
       local bufnr = vim.fn.bufnr(bufname, true)
 
-      vim.api.nvim_buf_set_option_value('buftype', 'nofile', { buf = bufnr })
-      vim.api.nvim_buf_set_option_value('filetype', 'note', { buf = bufnr })
+      vim.api.nvim_set_option_value('buftype', 'nofile', { buf = bufnr })
+      vim.api.nvim_set_option_value('filetype', 'note', { buf = bufnr })
       vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, lines)
 
       vim.cmd.b(bufnr)
@@ -646,10 +646,18 @@ function M.create_buffer_commands()
     { nargs = '?' }
   )
 
+  vim.api.nvim_buf_create_user_command(
+    0,
+    'NoteConvertLinksSquareToCurly',
+    util.convert_link_square_to_curly,
+    {}
+  )
+
   vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     buffer = 0,
     callback = make_intermediate_directories
   })
+
 end
 
 function M.create_buffer_keymaps(prefix)

--- a/lua/note/items.lua
+++ b/lua/note/items.lua
@@ -407,7 +407,7 @@ end
 --- @return Link | nil
 function M.get_link_at_col(line, col)
   -- TODO test
-  local matched = string_match_at(line, '%[(.-)%]', col)
+  local matched = string_match_at(line, '%{{(.-)%}}', col)
 
   if matched == nil or matched.matches[1] == nil then return end
 
@@ -450,7 +450,7 @@ function M.link_to_str(link)
     '|'
   )
 
-  return '[' .. file_part .. link_part .. ']'
+  return '{{' .. file_part .. link_part .. '}}'
 end
 
 return M

--- a/lua/note/util.lua
+++ b/lua/note/util.lua
@@ -108,4 +108,9 @@ function M.timestamp()
   return vim.fn.strftime('%I:%M.%S %p')
 end
 
+function M.convert_link_square_to_curly()
+  vim.cmd([[%s/\v\[(.{-}\|.{-})\]/\{\{\1}}/egc]])
+  vim.cmd([[%s/\v\[(\(.{-}\))\]/\{\{\1}}/egc]])
+end
+
 return M

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -3,7 +3,14 @@ vim.filetype.add({
     note = 'note',
   },
   pattern = {
-    ['.*/notes/.*'] = { 'note', { priority = -1 } }
+    ['(.*)/notes/.*'] = {
+      function(path, bufnr, prefix)
+        if not prefix:match('(.+)://') then -- ignore URI's
+          return 'note'
+        end
+      end,
+      { priority = -math.huge }
+    }
   }
 })
 

--- a/queries/note/highlights.scm
+++ b/queries/note/highlights.scm
@@ -31,26 +31,25 @@
 (section_header) @markup.heading.1
 
 (section
-  (section_children
-    (section
-      ((section_header) @markup.heading.2))))
+  (section
+    ((section_header) @markup.heading.2)))
 
 
 (section
-  (section_children
+  (section
     (section
-      (section_children
-        (section
-          ((section_header) @markup.heading.3))))))
+      ((section_header) @markup.heading.3))))
 
 
 (section
-  (section_children
+  (section
     (section
-      (section_children
-        (section
-          (section_children
-            (section
-              ((section_header) @markup.heading.4))))))))
+      (section
+        ((section_header) @markup.heading.4)))))
 
+(decorator_select) @note.decorator.select
+(decorator_flow) @note.decorator.flow
+(decorator_warn) @note.decorator.warn
+(decorator_question) @note.decorator.question
 
+(link) @note.link


### PR DESCRIPTION
This will break the current queries and may result in a lot of error messages. If you're using tree-sitter-note, you'll need to update it:

1. start nvim and run `:TSUninstall note`
2. close nvim
3. start nvim and load note (`:Note` or `:Lazy load note.nvim`)
4. `:TSInstall note`

**The link format has changed from `[<link>]` to `{{<link>}}`**. Use `:NoteConvertLinksSquareToCurly` in files with square bracket links to update them.

Tree-sitter node changes:
- section_children has been removed to be consistent with items (items just contain items, sections contain sections)
- decorators and links have been added
- item bodies can no longer start with any marker characters

Related grammar PR:
gsuuon/tree-sitter-note#1

